### PR TITLE
fix: added logic to make priority score zero when canStart is false

### DIFF
--- a/backend/algorithm/priorityAlgorithm.js
+++ b/backend/algorithm/priorityAlgorithm.js
@@ -1,4 +1,7 @@
 const priorityScore = (task) => {
+    if (task.canStart === false) {
+        return 0;
+    }
     ONE_DAY_IN_SECONDS = 1000 * 60 * 60 * 24;
     //weights for each category
     WI = 0.3;


### PR DESCRIPTION
Description:

To align with @kaushik27mishra's feedback, I've implemented a change where dependent tasks are strictly tied to their master tasks and do not receive an independent priority score until their master task is completed.

Here's how this is achieved:
Zero Priority for Dependent Tasks: A dependent task's priority score is now set to 0 if its master task's `canStart` status is `false`. This ensures it's de-prioritized and won't appear high in the task list until its blocker is resolved.

In next PR:
Hierarchical Display in the frontend: Dependent tasks will always be indented under their master tasks in the task list. This visual hierarchy remains consistent, clearly showing their relationship.
Normal Priority upon Completion: Once a master task is `COMPLETED`, its dependent tasks' priority scores will revert to their normal calculation based on the existing algorithm. At this point, they will assume their rightful position in the task list according to their newly calculated priority.


Test plan:
The priority score is zero because it is a dependent task and its canStart status is false
<img width="1512" height="982" alt="Screenshot 2025-07-13 at 8 20 52 PM" src="https://github.com/user-attachments/assets/203c0e6a-3dd7-49c0-b7c3-086d5020c021" />
