### PR TITLE
added logic to make master task priority higher if it has tasks depending on it

### DIFF
--- a/backend/algorithm/priorityAlgorithm.js
+++ b/backend/algorithm/priorityAlgorithm.js
@@ -70,8 +70,9 @@ const priorityScore = (task, allTasks = []) => {
         allTasks.filter(t => t.dependencies && t.dependencies.includes(task.id)) :
         [];
     const hasDependencies = dependentTasks.length > 0;
+    const numberOfDependentTasks = hasDependencies ? dependentTasks.length : 0;
     const priority = hasDependencies ?
-        basePriority * (1 + DEPENDENCY_BOOST_PERCENTAGE / 100) :
+        basePriority * (1 + (DEPENDENCY_BOOST_PERCENTAGE / 100) * numberOfDependentTasks) :
         basePriority;
     return parseFloat(priority.toFixed(2));
 

--- a/backend/algorithm/priorityAlgorithm.js
+++ b/backend/algorithm/priorityAlgorithm.js
@@ -1,4 +1,4 @@
-const priorityScore = (task) => {
+const priorityScore = (task, allTasks = []) => {
     if (task.canStart === false) {
         return 0;
     }
@@ -16,6 +16,7 @@ const priorityScore = (task) => {
     const LOW_SCORE = 1;
     const SEVEN_DAYS = 7
     const ONE_DAY = 1
+    const DEPENDENCY_BOOST_PERCENTAGE = 20;
 
     //gets tasks from backend and assigns importance score based on priority chosen by user
     const importance = {
@@ -64,7 +65,14 @@ const priorityScore = (task) => {
         'LARGE': HIGH_SCORE,
     }[task.size];
 
-    const priority = (WI * importance + WD * urgency + WA * age + WS * size)
+    const basePriority = (WI * importance + WD * urgency + WA * age + WS * size);
+    const dependentTasks = allTasks.length > 0 ?
+        allTasks.filter(t => t.dependencies && t.dependencies.includes(task.id)) :
+        [];
+    const hasDependencies = dependentTasks.length > 0;
+    const priority = hasDependencies ?
+        basePriority * (1 + DEPENDENCY_BOOST_PERCENTAGE / 100) :
+        basePriority;
     return parseFloat(priority.toFixed(2));
 
 };


### PR DESCRIPTION
Description:

Per @nihasetty's feedback, I created a logic to make master task priority higher if it has tasks depending on it by 20%.

Test Plan:
The priority score is seen to be boosted to 2.64 from 2.2 because of the new task dependent on it

https://github.com/user-attachments/assets/8ef6a9b6-d28f-47b0-8668-00d98d67d879

