### PR TITLE
fix: ensure notifications in safari

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import TaskList from './components/TaskList';
 import NotificationsPage from './notifications/NotificationsPage';
 import { BrowserRouter as Router, Route, Routes, Navigate, Outlet } from 'react-router-dom';
 import Notification from './notifications/Notification';
-import { requestNotificationPermission, registerServiceWorker, foregroundMessageHandler, getFCMToken } from './notifications/notificationService';
+import { registerServiceWorker, foregroundMessageHandler, getFCMToken } from './notifications/notificationService';
 import { addNotification, processOfflineOperations } from './notifications/indexedDB';
 import * as api from './utils/api';
 
@@ -29,13 +29,10 @@ function App() {
     }
     const initializeNotifications = async () => {
       await registerServiceWorker();
-      if (isLoggedIn) {
-        const permissionStatus = await requestNotificationPermission();
-        if (permissionStatus) {
-          const fcmToken = await getFCMToken();
-          if (fcmToken) {
-            await api.notifications.registerToken(fcmToken);
-          }
+      if (isLoggedIn && Notification.permission === 'granted') {
+        const fcmToken = await getFCMToken();
+        if (fcmToken) {
+          await api.notifications.registerToken(fcmToken);
         }
       }
     };

--- a/frontend/src/notifications/notificationService.js
+++ b/frontend/src/notifications/notificationService.js
@@ -38,16 +38,14 @@ export const getFCMToken = async () => {
 
 export const requestNotificationPermission = async () => {
   const permission = await Notification.requestPermission();
-  if (permission === 'granted') {
-    await getFCMToken();
-  }
+  return permission === 'granted';
 }
 
 export const foregroundMessageHandler = (callback) => {
   return onMessage(messaging, (payload) => {
     const notificationTitle = payload.notification?.title || payload.data?.title || 'New Notification';
     const notificationBody = payload.notification?.body || payload.data?.body || '';
-    const DEFAULT_NOTIFICATION_ICON = '../zuno-icon.jpg';
+    const DEFAULT_NOTIFICATION_ICON = '/zuno-icon.jpg';
 
     const notificationOptions = {
       body: notificationBody,
@@ -64,7 +62,9 @@ export const foregroundMessageHandler = (callback) => {
     if (callback && typeof callback === 'function') {
       callback(payload);
     } else {
-      new Notification(notificationTitle, notificationOptions);
+      if (Notification.permission === 'granted' && localStorage.getItem('notifications_disabled') !== 'true') {
+        new Notification(notificationTitle, notificationOptions);
+      }
     }
   });
 }


### PR DESCRIPTION
Description:

Fixed code to successfully enable notifications in Safari browser by requesting permission only when the enable notifications button in `NotificationsPage` is clicked. This meets Safari's rule that Notification prompting can only be done by user gesture.

Milestone:
Towards Technical Challenge 2: Notification system

Test plan:
Notification in task page

https://github.com/user-attachments/assets/89f5c2d6-7ac5-4f81-8e3f-db02c9cedfe6

Notification in Pomodoro page

https://github.com/user-attachments/assets/13505bcc-fa08-44a8-8617-5bdca0e74eae



